### PR TITLE
read all the data before trying to decode

### DIFF
--- a/examples/resolver.html
+++ b/examples/resolver.html
@@ -47,16 +47,12 @@
       const qtype = document.getElementById('qtype').value || 'A';
       const method = document.getElementById('method').value || 'POST';
       const url = document.getElementById('url').value;
-      const headers = {
-        'Accept': 'application/dns-message',
-        'User-Agent': 'dohjs/0.1.7'
-      };
       if (!url) {
         alert('You forgot to provide a URL!');
         return;
       }
       const resolver = new doh.DohResolver(url);
-      resolver.query(qname, qtype, method, headers)
+      resolver.query(qname, qtype, method)
         .then(response => {
           document.getElementById('output').innerHTML = JSON.stringify(response, null, 4);
         })

--- a/lib/index.js
+++ b/lib/index.js
@@ -155,7 +155,7 @@ function sendDohMsg(packet, url, method, headers) {
     if (!headers) {
       headers = {
         'Accept': 'application/dns-message',
-        'User-Agent': 'dohjs/0.1.9'
+        'User-Agent': 'dohjs/0.2.0'
       };
     }
     if (method === 'POST') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -175,11 +175,19 @@ function sendDohMsg(packet, url, method, headers) {
       path: url.pathname + url.search,
       headers: headers
     };
+    let data;
     const request = transportModule.request(requestOptions, (response) => {
       response.on('data', (d) => {
-        const decoded = dnsPacket.decode(d);
+        if (!data) {
+          data = d;
+        } else {
+          data = Buffer.concat([data, d]);
+        }
+      });
+      response.on('end', () => {
+        const decoded = dnsPacket.decode(data);
         resolve(decoded);
-      })
+      });
     });
     request.on('error', (err) => {
       request.abort();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dohjs",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dohjs",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Do DNS over HTTPS lookups from your browser",
   "main": "lib/index.js",
   "dependencies": {


### PR DESCRIPTION
I wasn't making sure to read the whole response before trying to decode the message, so I would get errors if I didn't read the entire response after one 'data' event was fired. This fixes that