### PR TITLE
Change CORS Proxy UI to Switch

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,9 +67,6 @@
                 <div class="form-text small">
                   Where to send the DNS query
                 </div>
-                <div class="invalid-feedback">
-                  Looks like you forgot to provide a URL. Oops
-                </div>
               </div>
               <div>
                 <div class="custom-control custom-switch">

--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
   <!-- jQuery and Bootstrap-->
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" crossorigin="anonymous"></script>
-  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
 
 </head>
 <body>
@@ -64,23 +64,26 @@
                     </div>
                   </div>
                 </div>
-
                 <div class="form-text small">
                   Where to send the DNS query
-                  <br><br>
-                  <div class="row align-items-center pr-3">
-                    <p class="col-8 my-auto">
-                      <span class="font-weight-bold font-italic">Hint:</span> If you run into CORS issues, click the button to prepend a proxy to the URL.
-                      <br>See also: <a href="https://stackoverflow.com/a/43881141/9638991">Stack Overflow answer about CORS issues</a>
-                    </p>
-                    <button class="btn btn-sm btn-outline-primary col-4 my-auto" type="button" id="corsify">
-                      Use CORS Proxy
-                    </button>
-                  </div>
                 </div>
                 <div class="invalid-feedback">
                   Looks like you forgot to provide a URL. Oops
                 </div>
+              </div>
+              <div>
+                <div class="custom-control custom-switch">
+                  <input type="checkbox" class="custom-control-input" id="cors-switch">
+                  <label class="custom-control-label" for="cors-switch" style="user-select: none;">Use CORS Proxy</label>
+                  <a tabindex="0" class="btn p-0 float-right" role="button" data-toggle="popover" data-trigger="focus" target="_blank" data-html="true"
+                     data-content="The CORS proxy can be used to avoid CORS errors when the resolver does not response with the proper headers.
+                     See the <a href='https://github.com/byu-imaal/dohjs/blob/gh-pages/README.md'>Github README</a> for additional details.">
+                    <i class="far fa-question-circle"></i>
+                  </a>
+                </div>
+                <p class="small mt-1">
+                  <span class="font-weight-bold font-italic">Hint:</span> If you run into errors, the proxy may help
+                </p>
               </div>
               <div class="form-group">
                 <label for="doh-qname"></label><input class="form-control" type="text" id="doh-qname" name="doh-qname" value="" placeholder=".">

--- a/index.html
+++ b/index.html
@@ -47,10 +47,10 @@
             <h4>Try DoH!</h4>
           </div>
           <div class="card-body">
-            <form id="try-doh-form" class="needs-validation">
+            <form>
               <div class="form-group">
                 <label for="doh-url"></label>
-                <div class="input-group">
+                <div class="input-group  needs-validation" id="doh-url-form">
                   <input class="form-control" type="text" id="doh-url" name="doh-url" value=""  placeholder="e.g. https://example.com/dns-query" required>
                   <div class="input-group-append">
                     <button class="btn btn-outline-primary dropdown-toggle" title="Popular Resolvers" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>

--- a/main.js
+++ b/main.js
@@ -17,18 +17,6 @@ document.addEventListener('DOMContentLoaded', function(e) {
         e.preventDefault()
     });
 
-    const forms = document.getElementsByClassName('needs-validation');
-    // Loop over them and prevent submission
-    var validation = Array.prototype.filter.call(forms, function (form) {
-        form.addEventListener('submit', function (event) {
-            if (form.checkValidity() === false) {
-                event.preventDefault();
-                event.stopPropagation();
-            }
-            form.classList.add('was-validated');
-        }, false);
-    });
-
     // FUNCTIONS
     const errorFunction = (err) => {
         console.error(err);
@@ -50,9 +38,9 @@ document.addEventListener('DOMContentLoaded', function(e) {
     };
 
     const doDoh = function() {
-        const dohForm = document.getElementById('try-doh-form');
-        dohForm.classList.remove('needs-validation');
-        dohForm.classList.add('was-validated');
+        const urlForm = document.getElementById('doh-url-form');
+        urlForm.classList.remove('needs-validation');
+        urlForm.classList.add('was-validated');
 
         responseElem.childNodes.forEach(node => node.remove());
 

--- a/main.js
+++ b/main.js
@@ -1,13 +1,26 @@
 const cors_proxy = "https://cors.dohjs.workers.dev/";
 
 document.addEventListener('DOMContentLoaded', function(e) {
+    // CONSTANTS
     const responseElem = document.getElementById('doh-response');
     const $loadingModal = $('#loading-modal');
     const doDohBtn = document.getElementById('do-doh');
-    const corsifyBtn = document.getElementById("corsify");
     const urlInputElem = document.getElementById('doh-url');
     const urlDropdown = document.getElementById('url-dropdown');
+    const corsSwitch = document.getElementById('cors-switch');
 
+    // SET UP
+    // enable popovers
+    $(document).ready(function($){
+        $('[data-toggle="popover"]').popover();
+    });
+    // ignore clicks on popovers to make clicking links easier
+    $('body').on('mousedown', '.popover', function(e) {
+        e.preventDefault()
+    });
+
+
+    // FUNCTIONS
     const errorFunction = (err) => {
         console.error(err);
         $loadingModal.modal('hide');
@@ -34,9 +47,12 @@ document.addEventListener('DOMContentLoaded', function(e) {
 
         responseElem.childNodes.forEach(node => node.remove());
 
-        const url = urlInputElem.value;
+        let url = urlInputElem.value;
         if (!url) {
             return;
+        }
+        if (corsSwitch.checked) {
+            url = cors_proxy + url;
         }
         const method = document.getElementById('doh-method').value || 'POST';
         const qname = document.getElementById('doh-qname').value || '.';
@@ -49,41 +65,16 @@ document.addEventListener('DOMContentLoaded', function(e) {
           .catch(errorFunction);
     };
 
-    // just toggles button state
-    const toggleCORSButton = function() {
-        if (urlInputElem.value.includes(cors_proxy)) {
-            corsifyBtn.classList.remove("btn-outline-primary");
-            corsifyBtn.classList.add('btn-primary');
-            corsifyBtn.innerText = "Remove CORS Proxy";
-        }
-        else {
-            corsifyBtn.classList.remove('btn-primary');
-            corsifyBtn.classList.add("btn-outline-primary");
-            corsifyBtn.innerText = "Use CORS Proxy";
-        }
-    };
-
+    // handle clicking of 'send' button and enter key
     doDohBtn.addEventListener('click', doDoh);
-    urlInputElem.addEventListener('input', toggleCORSButton); // user may remove proxy in form
-
     document.body.addEventListener('keydown', function (e) {
         if (e.key === 'Enter') {
             doDoh();
         }
     });
 
-    corsifyBtn.addEventListener('click', function(e) {
-        if (!urlInputElem.value.includes(cors_proxy)) {
-            urlInputElem.value = cors_proxy + urlInputElem.value;
-        }
-        else {
-            urlInputElem.value = urlInputElem.value.substr(cors_proxy.length);
-        }
-        toggleCORSButton();
-    });
-
+    // set resolver url to selection from dropdown
     urlDropdown.addEventListener('click', function (e) {
-        console.log(e.target);
         if ("dohurl" in e.target.dataset) {
             urlInputElem.value = e.target.dataset.dohurl;
         }

--- a/main.js
+++ b/main.js
@@ -11,14 +11,23 @@ document.addEventListener('DOMContentLoaded', function(e) {
 
     // SET UP
     // enable popovers
-    $(document).ready(function($){
-        $('[data-toggle="popover"]').popover();
-    });
+    $('[data-toggle="popover"]').popover();
     // ignore clicks on popovers to make clicking links easier
     $('body').on('mousedown', '.popover', function(e) {
         e.preventDefault()
     });
 
+    const forms = document.getElementsByClassName('needs-validation');
+    // Loop over them and prevent submission
+    var validation = Array.prototype.filter.call(forms, function (form) {
+        form.addEventListener('submit', function (event) {
+            if (form.checkValidity() === false) {
+                event.preventDefault();
+                event.stopPropagation();
+            }
+            form.classList.add('was-validated');
+        }, false);
+    });
 
     // FUNCTIONS
     const errorFunction = (err) => {

--- a/main.js
+++ b/main.js
@@ -38,9 +38,7 @@ document.addEventListener('DOMContentLoaded', function(e) {
     };
 
     const doDoh = function() {
-        const urlForm = document.getElementById('doh-url-form');
-        urlForm.classList.remove('needs-validation');
-        urlForm.classList.add('was-validated');
+        document.getElementById('doh-url-form').classList.add('was-validated');
 
         responseElem.childNodes.forEach(node => node.remove());
 


### PR DESCRIPTION
* Changes the CORS proxy button to a switch
* Reduced help text around CORS and added info button
* Proxy URL is no longer shown in `doh-url`

I feel we no longer need to display the URL because the proxy is our own, not a third-party. 
In addition a switch now makes more sense than the button because the state change is the switch itself not the resolver URL field.

**New UI** (popover only shows on focus)
![image](https://user-images.githubusercontent.com/8595062/75084699-036aea00-54df-11ea-8906-f830db30c848.png)

---
* Removed validation for all but `doh-url` since currently that's the only thing that can fail
* Also updated dependency versions
