### PR TITLE
doh script tag

### DIFF
--- a/examples/doh-script/doh-script-example.html
+++ b/examples/doh-script/doh-script-example.html
@@ -1,0 +1,41 @@
+<!-- Example of sourcing a script using dohjs -->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport"
+        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>dohjs example</title>
+
+  <!-- Load doh-script tag and friends -->
+  <script src="../../dist/doh-script.js"></script>
+
+  <doh-script src="https://unpkg.com/react@16/umd/react.development.js" resolver="https://cloudflare-dns.com/dns-query"></doh-script>
+  <doh-script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" resolver="https://cloudflare-dns.com/dns-query"></doh-script>
+</head>
+<body>
+
+<!--Placeholder where we'll render our "react app" -->
+<div id="root"></div>
+
+<script>
+  function loadNormalScript(src) {
+    const script = document.createElement('script');
+    script.src = src;
+    document.head.appendChild(script);
+  }
+
+  /* wait until all our doh-scripts are loaded, then load scripts that depend on them */
+  document.addEventListener('doh-scripts-loaded', function(e) {
+    console.log('all doh-scripts loaded');
+    const myScripts = [
+      './doh-script-react-example.js'
+    ];
+    for (let script of myScripts) {
+      loadNormalScript(script);
+    }
+  });
+</script>
+</body>
+</html>

--- a/examples/doh-script/doh-script-react-example.js
+++ b/examples/doh-script/doh-script-react-example.js
@@ -1,0 +1,4 @@
+ReactDOM.render(
+  React.createElement("h1", null, "Hello, world!"),
+  document.getElementById('root')
+);

--- a/lib/doh-script/doh-script-elem.js
+++ b/lib/doh-script/doh-script-elem.js
@@ -1,0 +1,72 @@
+const dohscript = require('./doh-script-helpers');
+
+/**
+ * Custom element <doh-script> that allows you to bypass the user's system DNS resolver
+ */
+class DohScript extends HTMLElement {
+  constructor() {
+    super();
+  }
+
+  connectedCallback() {
+
+  }
+
+  load() {
+    return new Promise(((resolve, reject) => {
+      if (!this.getAttribute('resolver')) {
+        return reject('missing required attribute "resolver"');
+      }
+      if (!this.getAttribute('src')) {
+        return reject('missing required attribute "src"');
+      }
+      const method = this.getAttribute('method') || 'POST';
+      const dohUrl = this.getAttribute('resolver');
+      const scriptSrc = this.getAttribute('src');
+      dohscript.dnsLookupScriptDomain(scriptSrc, dohUrl, method)
+        .then(ip => {
+          return dohscript.getScript(scriptSrc, ip)
+        })
+        .then(code => {
+          return dohscript.addScriptToDOM(code)
+        })
+        .then(resolve)
+        .catch(reject);
+    }));
+  }
+
+  disconnectedCallback() {}
+
+  adoptedCallback() {}
+}
+
+customElements.define('doh-script', DohScript);
+
+/**
+ * Load <doh-script> tags in order
+ * Fire custom event ('doh-scripts-loaded') when all the <doh-script>s have been loaded
+ */
+document.addEventListener('DOMContentLoaded', async function(e) {
+  async function loadInSequence(dohScripts) {
+    const errors = [];
+    for (let script of dohScripts) {
+      try {
+        await script.load();
+      } catch (e) {
+        errors.push(e);
+      }
+    }
+    if (errors.length > 0) {
+      throw errors;
+    }
+  }
+  let dohScripts = document.getElementsByTagName('doh-script');
+  dohScripts = Array.prototype.slice.call(dohScripts);
+  try {
+    await loadInSequence(dohScripts);
+    const event = new CustomEvent('doh-scripts-loaded');
+    document.dispatchEvent(event);
+  } catch (e) {
+    throw e;
+  }
+});

--- a/lib/doh-script/doh-script-helpers.js
+++ b/lib/doh-script/doh-script-helpers.js
@@ -1,0 +1,79 @@
+const https = require('https');
+const doh = require('..');
+
+const dnsLookupScriptDomain = function(scriptSrc, dohUrl, method) {
+  return new Promise(((resolve, reject) => {
+    const scriptUrl = new URL(scriptSrc);
+    const hostname = scriptUrl.hostname;
+    const qtype = 'A'; // TODO: send queries for both A and AAAA records?
+    const resolver = new doh.DohResolver(dohUrl);
+    resolver.query(hostname, qtype, method)
+      .then(response => {
+        let ip;
+        if (response.answers && response.answers.length > 0) {
+          for (let answer of response.answers) {
+            if (answer.type === 'A') {
+              ip = answer.data;
+              break;
+            }
+          }
+        }
+        if (!ip) {
+          return reject(`DNS lookup failed. No records of type ${qtype} found for ${hostname}`);
+        }
+        return resolve(ip);
+      });
+  }));
+};
+
+const getScript = function(url, ip) {
+  return new Promise(((resolve, reject) => {
+    url = new URL(url);
+    const hostname = url.hostname;
+    const newUrl = new URL(url.toString().replace(hostname, ip));
+    let data = '';
+    const headers = {
+      'Accept': 'application/javascript'
+    };
+    let requestOptions = {
+      method: 'GET',
+      hostname: hostname,
+      port: newUrl.port || 443,
+      path: newUrl.pathname + newUrl.search,
+      headers: headers,
+      servername: hostname, // XXX: I don't even know if this works
+    };
+    const request = https.request(requestOptions, res => {
+      res.on('data', d => {
+        data += d;
+      });
+      res.on('end', () => {
+        return resolve(data);
+      })
+    });
+    request.on('error', (err) => {
+      request.abort();
+      reject(err);
+    });
+    request.end();
+  }));
+};
+
+const addScriptToDOM = function(code) {
+  return new Promise(((resolve, reject) => {
+    var script = document.createElement('script');
+    /* this method of loading script stolen from jQuery's DOMEval function */
+    script.text = code;
+    script.onerror = (err) => {
+      return reject(err);
+    };
+    document.head.appendChild(script);
+    return resolve();
+  }));
+};
+
+module.exports = {
+  dnsLookupScriptDomain: dnsLookupScriptDomain,
+  getScript: getScript,
+  addScriptToDOM: addScriptToDOM,
+};

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
   },
   "scripts": {
     "test": "./test.sh",
-    "start": "npx live-server --open=/examples/resolver.html .",
+    "start": "npx live-server",
     "prestart": "npm run build",
-    "build": "browserify lib/index.js --standalone doh -o dist/doh.js",
-    "prepare": "npm run build && npx terser dist/doh.js --compress --mangle --output=dist/doh.min.js",
-    "docs": "jsdoc2md lib/index.js > docs/README.md"
+    "build": "npm run dohjs && npm run doh-script",
+    "prepare": "npm run build",
+    "docs": "jsdoc2md lib/index.js > docs/README.md",
+    "dohjs": "browserify lib/index.js --standalone doh -o dist/doh.js && npx terser dist/doh.js --compress --mangle --output=dist/doh.min.js",
+    "doh-script": "browserify lib/doh-script/doh-script-elem.js lib/doh-script/doh-script-helpers.js -o dist/doh-script.js && npx terser dist/doh-script.js --compress --mangle --output=dist/doh-script.min.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
This adds a custom element called `<doh-script>` that allows you to bypass the system DNS resolver to fetch scripts.

```html
<doh-script src="https://unpkg.com/react@16/umd/react.development.js" resolver="https://cloudflare-dns.com/dns-query"></doh-script>
<doh-script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" resolver="https://cloudflare-dns.com/dns-query"></doh-script>
``` 

See examples/doh-script/doh-script-example.html for a full example.

## Process

The `<doh-script>` element does the following:
- Sends a DNS lookup of type A to its resolver (specified in the `resolver` attribute)
  - In the future, we may want to try looking up both A and AAAA. I think A is good enough for now.
- Fetches the script (sends an HTTP GET request)
- Adds a script element to the DOM and sets the text of it to the response we got in the previous step

## Notes
- The `<doh-script>` tags are loaded in the order they are specified.
- If one of them fails, it will keep loading the other scripts, then report the errors at the end
- You need to listen for the custom event `'doh-scripts-loaded` to know when all the `<doh-script>` have been loaded. At that point, you can load your custom JavaScript that depends on the `<doh-script>`s.

## In the future

- Research in depth how this depends on [Subject Alternative Names](https://en.wikipedia.org/wiki/Subject_Alternative_Name) and [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication), what we can do about it, and how this impacts security
- Discuss interoperability of `<doh-script>` tags with `<script>` tags.
- Add similar feature for `<link>`, `<img>`, etc.
