### PR TITLE
better printing of TXT and padding

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,6 +22,25 @@ document.addEventListener('DOMContentLoaded', function(e) {
     };
 
     const successFunction = (response) => {
+
+        // decode TXT buffer
+        for (const a of response['answers']) {
+            if (a.type === 'TXT') {
+                a.data = a.data.toString();
+            }
+        }
+        // replace padding buffer with length
+        for (const a of response['additionals']) {
+            if (a.type === 'OPT') {
+                for (const o of a['options']) {
+                    if (o['code'] === 12) {
+                        o.length = o.data.length;
+                        delete o.data;
+                    }
+                }
+            }
+        }
+
         responseElem.innerHTML = `<pre>${JSON.stringify(response, null, 4)}</pre>`;
         $loadingModal.modal('hide');
         doDohBtn.disabled = false;


### PR DESCRIPTION
* For `TXT` records in the answers section `data` has been changed from Buffer (list of ints) to a string via `toString90`
* For EDNS padding (additionals -> OPT -> options) `data` has been removed and replaced by `length` which is the length in bytes of the data buffer

These make answers much shorter vertically and actually useful for `TXT`