### PR TITLE
Add <doh-style> tag (closes #34)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,5 +2,5 @@
 
 Directory | Description
 ---|---
-[examples/basic](examples/basic) | Basic examples of using dohjs, including the `Resolver` class, and other helpful functions.
-[examples/doh-script](examples/doh-script) | This shows the use of the `<doh-script>` tag, which is basically like the `<script>` tag, only it loads scripts without using the user's system DNS resolver. 
+[basic](examples/basic) | Basic examples of using dohjs, including the `Resolver` class, and other helpful functions.
+[custom-elems](examples/custom-elems) | Shows example uses of the `<doh-script>` and `<doh-style>` tags, which allow you to load JavaScript and CSS using the DNS resolver of your choosing. 

--- a/examples/custom-elems/doh-script/doh-script-example.html
+++ b/examples/custom-elems/doh-script/doh-script-example.html
@@ -9,7 +9,7 @@
   <title>dohjs example</title>
 
   <!-- Load doh-script tag and friends -->
-  <script src="../../dist/doh-script.js"></script>
+  <script src="../../../dist/doh-elems.js"></script>
 
   <!-- Bypass system DNS resolver -->
   <doh-script src="https://unpkg.com/react@16/umd/react.development.js" resolver="https://1.1.1.1/dns-query"></doh-script>
@@ -31,7 +31,7 @@
   document.addEventListener('doh-scripts-loaded', function(e) {
     console.log('all doh-scripts loaded');
     const myScripts = [
-      './doh-script-react-example.js'
+      './react-app.js'
     ];
     for (let script of myScripts) {
       loadNormalScript(script);

--- a/examples/custom-elems/doh-script/react-app.js
+++ b/examples/custom-elems/doh-script/react-app.js
@@ -1,3 +1,4 @@
+/* This is loaded into doh-script-example.html once React and ReactDOM have been loaded */
 ReactDOM.render(
   React.createElement("h1", null, "Hello, world!"),
   document.getElementById('root')

--- a/examples/custom-elems/doh-style/doh-style-example.html
+++ b/examples/custom-elems/doh-style/doh-style-example.html
@@ -1,4 +1,4 @@
-<!-- Example of using the <doh-script> tag, sourcing a script using dohjs -->
+<!-- Example of using the <doh-style> tag, which lets you load -->
 <!doctype html>
 <html lang="en">
 <head>
@@ -19,6 +19,7 @@
 <div class="container-fluid" style="display: none;" id="root">
   <div class="row mt-5">
     <div class="col">
+      <!-- This alert was copied from https://getbootstrap.com/docs/4.4/components/alerts/#additional-content -->
       <div class="alert alert-success" role="alert">
         <h4 class="alert-heading">Well done!</h4>
         <p>Aww yeah, you successfully read this important alert message. This example text is going to run a bit longer so that you can see how spacing within an alert works with this kind of content.</p>

--- a/examples/custom-elems/doh-style/doh-style-example.html
+++ b/examples/custom-elems/doh-style/doh-style-example.html
@@ -1,0 +1,39 @@
+<!-- Example of using the <doh-script> tag, sourcing a script using dohjs -->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport"
+        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>dohjs example</title>
+
+  <!-- Load doh-style tag and friends -->
+  <script src="../../../dist/doh-elems.js"></script>
+
+  <doh-style src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" resolver="https://1.1.1.1/dns-query"></doh-style>
+</head>
+<body>
+
+<!-- Make it hidden until we load the css -->
+<div class="container-fluid" style="display: none;" id="root">
+  <div class="row mt-5">
+    <div class="col">
+      <div class="alert alert-success" role="alert">
+        <h4 class="alert-heading">Well done!</h4>
+        <p>Aww yeah, you successfully read this important alert message. This example text is going to run a bit longer so that you can see how spacing within an alert works with this kind of content.</p>
+        <hr>
+        <p class="mb-0">Whenever you need to, be sure to use margin utilities to keep things nice and tidy.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  document.addEventListener('doh-styles-loaded', function(e) {
+    console.log('all doh-styles loaded');
+    document.getElementById('root').style.display = 'block';
+  });
+</script>
+</body>
+</html>

--- a/lib/elements/doh-elem-utils.js
+++ b/lib/elements/doh-elem-utils.js
@@ -1,10 +1,10 @@
 const https = require('https');
 const doh = require('..');
 
-const dnsLookupScriptDomain = function(scriptSrc, dohUrl, method) {
+const dnsLookupResource = function(resource, dohUrl, method) {
   return new Promise(((resolve, reject) => {
-    const scriptUrl = new URL(scriptSrc);
-    const hostname = scriptUrl.hostname;
+    const resourceUrl = new URL(resource);
+    const hostname = resourceUrl.hostname;
     const qtype = 'A'; // TODO: send queries for both A and AAAA records?
     const resolver = new doh.DohResolver(dohUrl);
     resolver.query(hostname, qtype, method)
@@ -26,26 +26,27 @@ const dnsLookupScriptDomain = function(scriptSrc, dohUrl, method) {
   }));
 };
 
-const getScript = function(url, ip) {
+const getResource = function(url, ip, headers) {
   return new Promise(((resolve, reject) => {
     url = new URL(url);
     const hostname = url.hostname;
     const newUrl = new URL(url.toString().replace(hostname, ip));
-    let data = '';
-    const headers = {
-      'Accept': 'application/javascript'
-    };
+    let data;
     let requestOptions = {
       method: 'GET',
       hostname: hostname,
       port: newUrl.port || 443,
       path: newUrl.pathname + newUrl.search,
       headers: headers,
-      servername: hostname, // XXX: I don't even know if this works
+      servername: hostname, // XXX: I don't even know if this does anything in the browser
     };
     const request = https.request(requestOptions, res => {
       res.on('data', d => {
-        data += d;
+        if (!data) {
+          data = d;
+        } else {
+          data = Buffer.concat([data, d]);
+        }
       });
       res.on('end', () => {
         return resolve(data);
@@ -59,21 +60,44 @@ const getScript = function(url, ip) {
   }));
 };
 
+const addStylesheetToDOM = function(css) {
+  return new Promise(((resolve, reject) => {
+    var stylesheet = document.createElement('style');
+    var cssText = document.createTextNode(css);
+    stylesheet.appendChild(cssText);
+    document.head.appendChild(stylesheet);
+    return resolve();
+  }));
+};
+
 const addScriptToDOM = function(code) {
   return new Promise(((resolve, reject) => {
     var script = document.createElement('script');
     /* this method of loading script stolen from jQuery's DOMEval function */
     script.text = code;
-    script.onerror = (err) => {
-      return reject(err);
-    };
     document.head.appendChild(script);
     return resolve();
   }));
 };
 
+async function loadInSequence(dohScripts) {
+  const errors = [];
+  for (let script of dohScripts) {
+    try {
+      await script.load();
+    } catch (e) {
+      errors.push(e);
+    }
+  }
+  if (errors.length > 0) {
+    throw errors;
+  }
+}
+
 module.exports = {
-  dnsLookupScriptDomain: dnsLookupScriptDomain,
-  getScript: getScript,
+  dnsLookupResource: dnsLookupResource,
+  getResource: getResource,
   addScriptToDOM: addScriptToDOM,
+  addStylesheetToDOM: addStylesheetToDOM,
+  loadInSequence: loadInSequence
 };

--- a/lib/elements/doh-script-elem.js
+++ b/lib/elements/doh-script-elem.js
@@ -1,4 +1,4 @@
-const dohscript = require('./doh-script-helpers');
+const dohElemUtils = require('./doh-elem-utils');
 
 /**
  * Custom element <doh-script> that allows you to bypass the user's system DNS resolver
@@ -6,6 +6,9 @@ const dohscript = require('./doh-script-helpers');
 class DohScript extends HTMLElement {
   constructor() {
     super();
+    this.headers = {
+      'Accept': 'application/javascript'
+    };
   }
 
   connectedCallback() {
@@ -23,12 +26,12 @@ class DohScript extends HTMLElement {
       const method = this.getAttribute('method') || 'POST';
       const dohUrl = this.getAttribute('resolver');
       const scriptSrc = this.getAttribute('src');
-      dohscript.dnsLookupScriptDomain(scriptSrc, dohUrl, method)
+      dohElemUtils.dnsLookupResource(scriptSrc, dohUrl, method)
         .then(ip => {
-          return dohscript.getScript(scriptSrc, ip)
+          return dohElemUtils.getResource(scriptSrc, ip, this.headers)
         })
         .then(code => {
-          return dohscript.addScriptToDOM(code)
+          return dohElemUtils.addScriptToDOM(code)
         })
         .then(resolve)
         .catch(reject);
@@ -47,19 +50,7 @@ customElements.define('doh-script', DohScript);
  * Fire custom event ('doh-scripts-loaded') when all the <doh-script>s have been loaded
  */
 document.addEventListener('DOMContentLoaded', async function(e) {
-  async function loadInSequence(dohScripts) {
-    const errors = [];
-    for (let script of dohScripts) {
-      try {
-        await script.load();
-      } catch (e) {
-        errors.push(e);
-      }
-    }
-    if (errors.length > 0) {
-      throw errors;
-    }
-  }
+
   let dohScripts = document.getElementsByTagName('doh-script');
   dohScripts = Array.prototype.slice.call(dohScripts);
   if (dohScripts.length === 0) {
@@ -67,7 +58,7 @@ document.addEventListener('DOMContentLoaded', async function(e) {
     return;
   }
   try {
-    await loadInSequence(dohScripts);
+    await dohElemUtils.loadInSequence(dohScripts);
     const event = new CustomEvent('doh-scripts-loaded');
     document.dispatchEvent(event);
   } catch (e) {

--- a/lib/elements/doh-style-elem.js
+++ b/lib/elements/doh-style-elem.js
@@ -1,0 +1,63 @@
+const dohElemUtils = require('./doh-elem-utils');
+
+class DohStyle extends HTMLElement {
+  constructor() {
+    super();
+    this.headers = {
+      'Accept': 'text/css'
+    };
+  }
+
+  connectedCallback() {
+
+  }
+
+  load() {
+    return new Promise(((resolve, reject) => {
+      if (!this.getAttribute('resolver')) {
+        return reject('missing required attribute "resolver"');
+      }
+      if (!this.getAttribute('src')) {
+        return reject('missing required attribute "src"');
+      }
+      const method = this.getAttribute('method') || 'POST';
+      const dohUrl = this.getAttribute('resolver');
+      const stylesheetSrc = this.getAttribute('src');
+      dohElemUtils.dnsLookupResource(stylesheetSrc, dohUrl, method)
+        .then(ip => {
+          return dohElemUtils.getResource(stylesheetSrc, ip)
+        })
+        .then(css => {
+          return dohElemUtils.addStylesheetToDOM(css)
+        })
+        .then(resolve)
+        .catch(reject);
+    }));
+  }
+
+  disconnectedCallback() {}
+
+  adoptedCallback() {}
+}
+
+customElements.define('doh-style', DohStyle);
+
+/**
+ * Load <doh-style> tags in order
+ * Fire custom event ('doh-styles-loaded') when all the <doh-style>s have been loaded
+ */
+document.addEventListener('DOMContentLoaded', async function(e) {
+  let dohStyles = document.getElementsByTagName('doh-style');
+  dohStyles = Array.prototype.slice.call(dohStyles);
+  if (dohStyles.length === 0) {
+    /* just return, don't dispatch the 'doh-styles-loaded' event because no scripts were loaded */
+    return;
+  }
+  try {
+    await dohElemUtils.loadInSequence(dohStyles);
+    const event = new CustomEvent('doh-styles-loaded');
+    document.dispatchEvent(event);
+  } catch (e) {
+    throw e;
+  }
+});

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -54,20 +54,20 @@ test('DohResolver.query() for example.com TXT contains answers', () => {
 
 test('sendDohMsg() works (and the example.com zone still has an A record)', () => {
   let msg = makeQuery('example.com');
-  sendDohMsg(msg, 'https://cloudflare-dns.com/dns-query', 'GET').then(
+  sendDohMsg(msg, 'https://cloudflare-dns.com/dns-query', 'GET', null).then(
     response => {
       expect(response.answers.length).toBeGreaterThanOrEqual(1);
     }
   )
 });
 
-test('queryWithHeaders() works with no headers', () => {
+test('DohResolver.query() works with no/null headers', () => {
   const resolver = new DohResolver('https://cloudflare-dns.com/dns-query');
-  resolver.queryWithHeaders('example.com', 'A', 'POST')
+  resolver.query('example.com', 'A', 'POST')
     .then(response => expect(response.answers.length).toBeGreaterThanOrEqual(1));
 });
 
-test('queryWithHeaders() works with headers', () => {
+test('DohResolver.query() works with custom headers', () => {
   const resolver = new DohResolver('https://cloudflare-dns.com/dns-query');
   const headers = {
     /* without the "Accept: application/dns-message" header, it probably won't work */
@@ -76,6 +76,6 @@ test('queryWithHeaders() works with headers', () => {
     'Favorite-Color': 'purple',
     'Least-Favorite-Color': 'gray'
   };
-  resolver.queryWithHeaders('example.com', 'A', 'GET', headers)
+  resolver.query('example.com', 'A', 'GET', headers)
     .then(response => expect(response.answers.length).toBeGreaterThanOrEqual(1));
 });

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "test": "./test.sh",
     "start": "npx live-server",
     "prestart": "npm run build",
-    "build": "npm run dohjs && npm run doh-script",
+    "build": "npm run dohjs && npm run doh-elems",
     "prepare": "npm run build",
     "docs": "jsdoc2md lib/index.js > docs/README.md",
     "dohjs": "browserify lib/index.js --standalone doh -o dist/doh.js && npx terser dist/doh.js --compress --mangle --output=dist/doh.min.js",
-    "doh-script": "browserify lib/doh-script/doh-script-elem.js lib/doh-script/doh-script-helpers.js -o dist/doh-script.js && npx terser dist/doh-script.js --compress --mangle --output=dist/doh-script.min.js"
+    "doh-elems": "browserify lib/elements/doh-elem-utils.js lib/elements/doh-script-elem.js lib/elements/doh-style-elem.js -o dist/doh-elems.js && npx terser dist/doh-elems.js --compress --mangle --output=dist/doh-elems.min.js"
   },
   "repository": {
     "type": "git",

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# exit if anything fails
+set -e
+
 # run integrated tests
 jest
 


### PR DESCRIPTION
## Summary
This adds code for the `<doh-style>` tag, which allows loading CSS using the DoH resolver of your choice for the DNS lookup(s).

I added an example for `<doh-style>`. Also did a bit of refactoring to fit the doh-elems better into dohjs, since we're going to have more custom elements (at least #31). 

## TODO after this merges

- add `<doh-style>` tag in to the main README 
- new minor version bump and pre-release

Also probably should write some tests for this, at least for doh-elem-utils.js.