### PR TITLE
add <doh-img> tag

### DIFF
--- a/examples/custom-elems/doh-img/doh-img-example.html
+++ b/examples/custom-elems/doh-img/doh-img-example.html
@@ -1,0 +1,19 @@
+<!-- Example of using the <doh-img> tag, load an image using the DoH resolver of your choice -->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport"
+        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>dohjs example</title>
+
+  <!-- Load doh-img tag and friends -->
+  <script src="../../../dist/doh-elems.js"></script>
+</head>
+<body>
+
+<doh-img src="https://dohjs.org/dohjs.png" resolver="https://1.1.1.1/dns-query"></doh-img>
+
+</body>
+</html>

--- a/lib/elements/doh-elem-utils.js
+++ b/lib/elements/doh-elem-utils.js
@@ -60,26 +60,6 @@ const getResource = function(url, ip, headers) {
   }));
 };
 
-const addStylesheetToDOM = function(css) {
-  return new Promise(((resolve, reject) => {
-    var stylesheet = document.createElement('style');
-    var cssText = document.createTextNode(css);
-    stylesheet.appendChild(cssText);
-    document.head.appendChild(stylesheet);
-    return resolve();
-  }));
-};
-
-const addScriptToDOM = function(code) {
-  return new Promise(((resolve, reject) => {
-    var script = document.createElement('script');
-    /* this method of loading script stolen from jQuery's DOMEval function */
-    script.text = code;
-    document.head.appendChild(script);
-    return resolve();
-  }));
-};
-
 async function loadInSequence(dohScripts) {
   const errors = [];
   for (let script of dohScripts) {
@@ -97,7 +77,5 @@ async function loadInSequence(dohScripts) {
 module.exports = {
   dnsLookupResource: dnsLookupResource,
   getResource: getResource,
-  addScriptToDOM: addScriptToDOM,
-  addStylesheetToDOM: addStylesheetToDOM,
   loadInSequence: loadInSequence
 };

--- a/lib/elements/doh-img-elem.js
+++ b/lib/elements/doh-img-elem.js
@@ -1,0 +1,56 @@
+const dohElemUtils = require('./doh-elem-utils');
+
+/**
+ * Custom element <doh-script> that allows you to bypass the user's system DNS resolver
+ */
+class DohImg extends HTMLElement {
+  constructor() {
+    super();
+    this.headers = {
+      'Accept': 'image/*'
+    };
+  }
+
+  async connectedCallback() {
+    try {
+      await this.load();
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  load() {
+    return new Promise(((resolve, reject) => {
+      if (!this.getAttribute('resolver')) {
+        return reject('missing required attribute "resolver"');
+      }
+      if (!this.getAttribute('src')) {
+        return reject('missing required attribute "src"');
+      }
+      const method = this.getAttribute('method') || 'POST';
+      const dohUrl = this.getAttribute('resolver');
+      const scriptSrc = this.getAttribute('src');
+      dohElemUtils.dnsLookupResource(scriptSrc, dohUrl, method)
+        .then(ip => {
+          return dohElemUtils.getResource(scriptSrc, ip, this.headers)
+        })
+        .then(imgBytes => {
+          return this.addImageToDOM(imgBytes)
+        })
+        .then(resolve)
+        .catch(reject);
+    }));
+  }
+
+  addImageToDOM(imgBytes) {
+    const img = document.createElement('img');
+    img.src = "data:image/png;base64," + imgBytes.toString('base64');
+    this.appendChild(img);
+  }
+
+  disconnectedCallback() {}
+
+  adoptedCallback() {}
+}
+
+customElements.define('doh-img', DohImg);

--- a/lib/elements/doh-script-elem.js
+++ b/lib/elements/doh-script-elem.js
@@ -31,12 +31,22 @@ class DohScript extends HTMLElement {
           return dohElemUtils.getResource(scriptSrc, ip, this.headers)
         })
         .then(code => {
-          return dohElemUtils.addScriptToDOM(code)
+          return this.addScriptToDOM(code)
         })
         .then(resolve)
         .catch(reject);
     }));
   }
+
+  addScriptToDOM = function(code) {
+    return new Promise(((resolve, reject) => {
+      var script = document.createElement('script');
+      /* this method of loading script stolen from jQuery's DOMEval function */
+      script.text = code;
+      document.head.appendChild(script);
+      return resolve();
+    }));
+  };
 
   disconnectedCallback() {}
 

--- a/lib/elements/doh-style-elem.js
+++ b/lib/elements/doh-style-elem.js
@@ -28,12 +28,22 @@ class DohStyle extends HTMLElement {
           return dohElemUtils.getResource(stylesheetSrc, ip)
         })
         .then(css => {
-          return dohElemUtils.addStylesheetToDOM(css)
+          return this.addStylesheetToDOM(css)
         })
         .then(resolve)
         .catch(reject);
     }));
   }
+
+  addStylesheetToDOM = function(css) {
+    return new Promise(((resolve, reject) => {
+      var stylesheet = document.createElement('style');
+      var cssText = document.createTextNode(css);
+      stylesheet.appendChild(cssText);
+      document.head.appendChild(stylesheet);
+      return resolve();
+    }));
+  };
 
   disconnectedCallback() {}
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepare": "npm run build",
     "docs": "jsdoc2md lib/index.js > docs/README.md",
     "dohjs": "browserify lib/index.js --standalone doh -o dist/doh.js && npx terser dist/doh.js --compress --mangle --output=dist/doh.min.js",
-    "doh-elems": "browserify lib/elements/doh-elem-utils.js lib/elements/doh-script-elem.js lib/elements/doh-style-elem.js -o dist/doh-elems.js && npx terser dist/doh-elems.js --compress --mangle --output=dist/doh-elems.min.js"
+    "doh-elems": "browserify lib/elements/doh-elem-utils.js lib/elements/doh-script-elem.js lib/elements/doh-style-elem.js lib/elements/doh-img-elem.js -o dist/doh-elems.js && npx terser dist/doh-elems.js --compress --mangle --output=dist/doh-elems.min.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
added the `<doh-img>` tag, which allows you to load images using the resolver of your choice.

Also did a bit of refactoring in the doh-elem-utils.js, and added an example for `<doh-img>`