### PR TITLE
Add 'prettify' function to library and overhaul CLI

### DIFF
--- a/bin/doh.js
+++ b/bin/doh.js
@@ -58,7 +58,7 @@ parser.addArgument('qtype',
     {help: 'Query type. Default is "A"', defaultValue: 'A', nargs: '?'});
 
 // DNS OPTIONS (+)
-parser.addArgument('+ecs',
+parser.addArgument('+subnet',
   {help: 'EDNS Client Subnet option to include, in the format <address>/<source-prefix-len>', dest: '_subnet',
     metavar: '<address>/<source-prefix-len>'});
 parser.addArgument('+dnssec',

--- a/bin/doh.js
+++ b/bin/doh.js
@@ -64,8 +64,8 @@ parser.addArgument('+ecs',
 parser.addArgument('+dnssec',
     {help: 'Send DNSSEC OK bit', action: 'storeTrue'});
 parser.addArgument('+edns',
-    {help: 'Send arbitrary EDNS options in the format of <opt-code>:<hex-data>', metavar: '<opt-code>:<hex-data>',
-      action: 'append', dest: '_edns'})
+    {help: 'Send arbitrary EDNS options in the format of <opt-code>:<hex-data>. Can repeat arg multiple times',
+      metavar: '<opt-code>:<hex-data>', action: 'append', dest: '_edns'})
 
 // OTHER OPTIONS (-)
 parser.addArgument(['-m', '--method'],

--- a/bin/doh.js
+++ b/bin/doh.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-const {makeQuery, sendDohMsg} = require('..');
+const {makeQuery, sendDohMsg, prettify} = require('..');
 const dnsPacket = require('dns-packet');
 
 /**
@@ -113,6 +113,21 @@ parser.addArgument(
     metavar: '<address>/<source-prefix-len>'
   }
 );
+parser.addArgument(
+  ['-c', '--compact'],
+  {
+    help: 'Prints in compact form (1 line) as opposed to pretty-printed json',
+    action: 'storeTrue'
+  }
+)
+parser.addArgument(
+    ['--dnssec'],
+  {
+    help: 'Send DNSSEC OK bit',
+    action: 'storeTrue',
+    dest: 'dnssecOk'
+  }
+)
 let args = parser.parseArgs();
 if (args._subnet) {
   let split = args._subnet.split('/');
@@ -125,7 +140,7 @@ if (args._subnet) {
 
 dohLookup(args)
   .then(response => {
-    console.log(JSON.stringify(response))
+    console.log(JSON.stringify(prettify(response), null, args.compact ? 0 : 2))
   })
   .catch(reason => {
     console.error(reason);

--- a/bin/doh.js
+++ b/bin/doh.js
@@ -3,22 +3,7 @@
 
 const {makeQuery, sendDohMsg, prettify} = require('..');
 const dnsPacket = require('dns-packet');
-
-/**
- * Default DoH lookup options
- *
- * @type {{dnssecOk: boolean, method: string, qtype: string, qname: string, ecsAddress: string, noRecursion: boolean, ecsSourcePrefixLength: number, url: null}}
- */
-const defaultDohLookupOptions = {
-  url: null,
-  qtype: 'A',
-  qname: '.',
-  noRecursion: false,
-  dnssecOk: false,
-  method: 'POST',
-  ecsAddress: '0.0.0.0',
-  ecsSourcePrefixLength: 0,
-};
+const ArgumentParser = require('argparse').ArgumentParser;
 
 /**
  * Perform a DNS over HTTPS lookup given options.
@@ -26,40 +11,25 @@ const defaultDohLookupOptions = {
  * See `defaultDohLookupOptions` above for list of options
  * and their defaults
  *
- * @param options {object} DNS lookup options
- * @returns {Promise<dnsPacket>}
+ * @param options {object} DNS lookup options as created by argparse
+ * @returns {[<dnsPacket>, Promise<dnsPacket>]} the generated query and the response promise
  */
 function dohLookup(options) {
-  var url = options.url || defaultDohLookupOptions.url;
-  if (!url) {
-    throw new Error('Must provide a URL to send DoH lookup to');
-  }
-  const flags = options.noRecursion ? 0 : dnsPacket.RECURSION_DESIRED;
-  const type = options.qtype || defaultDohLookupOptions.qtype;
-  const name = options.qname || defaultDohLookupOptions.qname;
-  const method = options.method || defaultDohLookupOptions.method;
-  let dnsMessage = makeQuery(name, type);
-  dnsMessage.flags = flags;
-  if (options.dnssecOk) {
+  let dnsMessage = makeQuery(options.qname, options.qtype);
+
+  if (options.dnssec || (options.edns && options.edns.length > 0) || options.ecsAddress) {
     dnsMessage.additionals = [{
       type: 'OPT',
       name: '.',
       udpPayloadSize: 4096,
-      flags: dnsPacket.DNSSEC_OK,
-      options: []
+      flags: options.dnssec ? dnsPacket.DNSSEC_OK : 0,
+      options: options.edns || []
     }]
   }
+
   if (options.ecsAddress) {
     const family = options.ecsAddress.indexOf(':') !== -1 ? 2 : 1;
-    const sourcePrefixLength = options.sourcePrefixLength || defaultDohLookupOptions.sourcePrefixLength;
-    if (!dnsMessage.additionals || !dnsMessage.additionals.length) {
-      dnsMessage.additionals = [{
-        type: 'OPT',
-        name: '.',
-        udpPayloadSize: 4096,
-        options: []
-      }]
-    }
+    const sourcePrefixLength = options.sourcePrefixLength;
     dnsMessage.additionals[0].options.push({
       code: 8,
       family: family,
@@ -68,79 +38,75 @@ function dohLookup(options) {
       ip: options.ecsAddress
     })
   }
-  return sendDohMsg(dnsMessage, url, method);
+
+  return [dnsMessage, sendDohMsg(dnsMessage, options.url, options.method, null, 0)];
 }
 
-const ArgumentParser = require('argparse').ArgumentParser;
-
 let parser = new ArgumentParser({
-  version: '0.1.0',
+  version: '0.2.0',
   addHelp: true,
-  description: 'DNS over HTTPS lookup command line tool'
+  description: 'DNS over HTTPS lookup command line tool',
+  prefixChars: '-+' // dig has done this to me
 });
-parser.addArgument(
-  'url',
-  {
-    help: 'URL to send the DNS request to'
-  }
-);
-parser.addArgument(
-  ['-m', '--method'],
-  {
-    help: 'Request method to use (GET or POST). Default is "POST"',
-    choices: ['GET', 'POST']
-  }
-);
-parser.addArgument(
-  ['-q', '--qname'],
-  {
-    help: 'Name to query for. Default is "."',
-    defaultValue: '.'
-  }
-);
-parser.addArgument(
-  ['-t', '--qtype'],
-  {
-    help: 'Query type. Default is "A"',
-    defaultValue: 'A'
-  }
-);
-parser.addArgument(
-  ['--ecs', '--subnet'],
-  {
-    help: 'EDNS Client Subnet option to include, in the format <address>/<source-prefix-len>',
-    dest: '_subnet',
-    metavar: '<address>/<source-prefix-len>'
-  }
-);
-parser.addArgument(
-  ['-c', '--compact'],
-  {
-    help: 'Prints in compact form (1 line) as opposed to pretty-printed json',
-    action: 'storeTrue'
-  }
-)
-parser.addArgument(
-    ['--dnssec'],
-  {
-    help: 'Send DNSSEC OK bit',
-    action: 'storeTrue',
-    dest: 'dnssecOk'
-  }
-)
+
+// BASE POSITIONALS
+parser.addArgument('url',
+    {help: 'URL to send the DNS request to'});
+parser.addArgument('qname',
+    {help: 'Name to query for. Default is "."', defaultValue: '.', nargs: '?'});
+parser.addArgument('qtype',
+    {help: 'Query type. Default is "A"', defaultValue: 'A', nargs: '?'});
+
+// DNS OPTIONS (+)
+parser.addArgument('+ecs',
+  {help: 'EDNS Client Subnet option to include, in the format <address>/<source-prefix-len>', dest: '_subnet',
+    metavar: '<address>/<source-prefix-len>'});
+parser.addArgument('+dnssec',
+    {help: 'Send DNSSEC OK bit', action: 'storeTrue'});
+parser.addArgument('+edns',
+    {help: 'Send arbitrary EDNS options in the format of <opt-code>:<hex-data>', metavar: '<opt-code>:<hex-data>',
+      action: 'append', dest: '_edns'})
+
+// OTHER OPTIONS (-)
+parser.addArgument(['-m', '--method'],
+    {help: 'Request method to use (GET or POST). Default is "POST"', choices: ['GET', 'POST'], defaultValue: 'POST'});
+parser.addArgument(['-s', '--short'],
+    {help: 'Prints in short form (1 line) as opposed to pretty-printed json', action: 'storeTrue'});
+parser.addArgument(['-d', '--debug'],
+    {help: 'Prints the generated query in addition to the response', action: 'storeTrue'})
+
+
+// PARSING
 let args = parser.parseArgs();
 if (args._subnet) {
   let split = args._subnet.split('/');
   if (split.length !== 2) {
-    parser.exit(1, 'Invalid format for --ecs/--subnet option. Must be "<address>/<source-prefix-len>"\n');
+    parser.exit(1, 'Invalid format for +subnet option. Must be "<address>/<source-prefix-len>"\n');
   }
   args.ecsAddress = split[0];
   args.sourcePrefixLength = split[1];
 }
+if (args._edns) {
+  args.edns = []
+  for (const opt of args._edns) {
+    let split = opt.split(':')
+    if (split.length !== 2) {
+      parser.exit(1, 'Invalid format for +edns. Must be"<opt-code>:<hex-data>"\n')
+    }
+    args.edns.push({code: parseInt(split[0]), data: Buffer.of(split[1], 'hex')})
+  }
+}
 
-dohLookup(args)
-  .then(response => {
-    console.log(JSON.stringify(prettify(response), null, args.compact ? 0 : 2))
+// LOOKUP
+const [query, response] = dohLookup(args);
+if (args.debug) {
+  console.log("QUERY:")
+  console.log(JSON.stringify(prettify(query), null, args.short ? 0 : 2))
+  console.log("*".repeat(80));
+  console.log("RESPONSE:")
+}
+response.then(response => {
+    console.log(JSON.stringify(prettify(response), null, args.short ? 0 : 2))
   })
   .catch(reason => {
     console.error(reason);

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,32 +15,35 @@ It will by default dump the response as JSON.
 
 If you want to fiddle with the output format, feel free to modify bin/doh.js as you see fit (pull requests welcome!)
 
-Feel free to pipe to `jq` for prettier output:
-```bash
-dohjs https://dns.google/dns-query | jq
-```
 
 Here's the usage for it:
 ```
-usage: dohjs [-h] [-v] [-m {GET,POST}] [-q QNAME] [-t QTYPE]
-              [--ecs <address>/<source-prefix-len>]
-              url
- 
- DNS over HTTPS lookup command line tool
- 
- Positional arguments:
-   url                   URL to send the DNS request to
- 
- Optional arguments:
-   -h, --help            Show this help message and exit.
-   -v, --version         Show program's version number and exit.
-   -m {GET,POST}, --method {GET,POST}
-                         Request method to use (GET or POST). Default is "POST"
-   -q QNAME, --qname QNAME
-                         Name to query for. Default is "."
-   -t QTYPE, --qtype QTYPE
-                         Query type. Default is "A"
-   --ecs <address>/<source-prefix-len>, --subnet <address>/<source-prefix-len>
-                         EDNS Client Subnet option to include, in the format 
-                         <address>/<source-prefix-len>
+usage: doh.js [-h] [-v] [+ecs <address>/<source-prefix-len>] [+dnssec]
+              [+edns <opt-code>:<hex-data>] [-m {GET,POST}] [-s] [-d]
+              url [qname] [qtype]
+
+DNS over HTTPS lookup command line tool
+
+Positional arguments:
+  url                   URL to send the DNS request to
+  qname                 Name to query for. Default is "."
+  qtype                 Query type. Default is "A"
+
+Optional arguments:
+  -h, --help            Show this help message and exit.
+  -v, --version         Show program's version number and exit.
+  +ecs <address>/<source-prefix-len>
+                        EDNS Client Subnet option to include, in the format
+                        <address>/<source-prefix-len>
+  +dnssec               Send DNSSEC OK bit
+  +edns <opt-code>:<hex-data>
+                        Send arbitrary EDNS options in the format of
+                        <opt-code>:<hex-data>
+  -m {GET,POST}, --method {GET,POST}
+                        Request method to use (GET or POST). Default is "POST"
+  -s, --short           Prints in short form (1 line) as opposed to
+                        pretty-printed json
+  -d, --debug           Prints the generated query in addition to the response
+
 ```
+Note that options controlling the DNS message are denoted with `+` while other options use `-`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,7 +32,7 @@ Positional arguments:
 Optional arguments:
   -h, --help            Show this help message and exit.
   -v, --version         Show program's version number and exit.
-  +ecs <address>/<source-prefix-len>
+  +subnet <address>/<source-prefix-len>
                         EDNS Client Subnet option to include, in the format
                         <address>/<source-prefix-len>
   +dnssec               Send DNSSEC OK bit

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 const dnsPacket = require('dns-packet');
 const https = require('https');
 const http = require('http');
+const base32Encode = require('base32-encode')
 
 /**
  * Allowed request methods for sending DNS over HTTPS requests.
@@ -209,12 +210,51 @@ function sendDohMsg(packet, url, method, headers, timeout) {
   });
 }
 
+
+/**
+ * 'Prettifies' a dnsPacket message.
+ *
+ * Namely, this convert Buffer's the the appropriate presentation format.
+ * This is useful to make json human readable.
+ *
+ * DNSKEY:B64, DS:HEX, NSEC3 salt:HEX, next:B32, NULL, EDNS in general, RRSIG:B64, TXT:UTF-8
+
+ *
+ * @param msg {object} a dnsPacket
+ */
+function prettify(msg) {
+  for (const rr of msg['answers'].concat(msg['authorities'])) {
+    if (rr.hasOwnProperty('data')) {
+      switch (rr.type) {
+        case 'TXT':
+          rr.data = rr.data.toString()
+          break;
+        case 'DNSKEY':
+          rr.data.key = rr.data.key.toString('base64')
+          break;
+        case 'DS':
+          rr.data.digest = rr.data.digest.toString('hex')
+          break;
+        case 'NSEC3':
+          rr.data.salt = rr.data.salt.toString('hex');
+          rr.data.nextDomain = base32Encode(rr.data.nextDomain, 'RFC4648-HEX', {padding: false})
+          break;
+        case 'RRSIG':
+          rr.data.signature = rr.data.signature.toString('base64');
+          break;
+      }
+    }
+  }
+  return msg
+}
+
 const dohjs = {
   sendDohMsg: sendDohMsg,
   DohResolver: DohResolver,
   makeQuery: makeQuery,
   MethodNotAllowedError: MethodNotAllowedError,
-  isMethodAllowed: isMethodAllowed
+  isMethodAllowed: isMethodAllowed,
+  prettify: prettify
 };
 
 module.exports = dohjs;

--- a/lib/index.js
+++ b/lib/index.js
@@ -217,13 +217,14 @@ function sendDohMsg(packet, url, method, headers, timeout) {
  * Namely, this convert Buffer's the the appropriate presentation format.
  * This is useful to make json human readable.
  *
- * DNSKEY:B64, DS:HEX, NSEC3 salt:HEX, next:B32, NULL, EDNS in general, RRSIG:B64, TXT:UTF-8
-
+ * *NOTE* This function may modify the message such that it no longer works with dnsPacket.
+ * Caution should be used when calling this object on query packets before sending them
  *
  * @param msg {object} a dnsPacket
+ * @returns {object} the msg which has been modified in-place. *May not be a valid dnsPacket afterwards*
  */
 function prettify(msg) {
-  for (const rr of msg['answers'].concat(msg['authorities'])) {
+  for (const rr of (msg['answers'] || []).concat((msg['authorities'] || []))) {
     if (rr.hasOwnProperty('data')) {
       switch (rr.type) {
         case 'TXT':
@@ -251,13 +252,15 @@ function prettify(msg) {
         switch(opt.code) {
           case 12:
             opt.length = opt.data.length;
-            delete opt.data;
+            opt.data = opt.data.toString('hex').substring(0, 80);
+            if (opt.data.length === 80 ) {
+              opt.data += '...'
+            }
             break;
         }
       }
     }
   }
-
   return msg
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -214,14 +214,14 @@ function sendDohMsg(packet, url, method, headers, timeout) {
 /**
  * 'Prettifies' a dnsPacket message.
  *
- * Namely, this convert Buffer's the the appropriate presentation format.
+ * Namely, this convert Buffers the the appropriate presentation format.
  * This is useful to make json human readable.
  *
  * *NOTE* This function may modify the message such that it no longer works with dnsPacket.
  * Caution should be used when calling this object on query packets before sending them
  *
  * @param msg {object} a dnsPacket
- * @returns {object} the msg which has been modified in-place. *May not be a valid dnsPacket afterwards*
+ * @returns {object} the msg which has been modified in-place. *May not be a valid <dnsPacket> afterwards*
  */
 function prettify(msg) {
   for (const rr of (msg['answers'] || []).concat((msg['authorities'] || []))) {
@@ -246,7 +246,7 @@ function prettify(msg) {
       }
     }
   }
-  for (const rr of msg['additionals']) {
+  for (const rr of (msg['additionals'] || [])) {
     if (rr.type === 'OPT') {
       for (const opt of rr['options']) {
         switch(opt.code) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -227,24 +227,37 @@ function prettify(msg) {
     if (rr.hasOwnProperty('data')) {
       switch (rr.type) {
         case 'TXT':
-          rr.data = rr.data.toString()
+          rr.data = rr.data.toString('utf8');
           break;
         case 'DNSKEY':
-          rr.data.key = rr.data.key.toString('base64')
+          rr.data.key = rr.data.key.toString('base64').replace('=', '');
           break;
         case 'DS':
-          rr.data.digest = rr.data.digest.toString('hex')
+          rr.data.digest = rr.data.digest.toString('hex');
           break;
         case 'NSEC3':
           rr.data.salt = rr.data.salt.toString('hex');
-          rr.data.nextDomain = base32Encode(rr.data.nextDomain, 'RFC4648-HEX', {padding: false})
+          rr.data.nextDomain = base32Encode(rr.data.nextDomain, 'RFC4648-HEX').replace('=', '')
           break;
         case 'RRSIG':
-          rr.data.signature = rr.data.signature.toString('base64');
+          rr.data.signature = rr.data.signature.toString('base64').replace('=', '');
           break;
       }
     }
   }
+  for (const rr of msg['additionals']) {
+    if (rr.type === 'OPT') {
+      for (const opt of rr['options']) {
+        switch(opt.code) {
+          case 12:
+            opt.length = opt.data.length;
+            delete opt.data;
+            break;
+        }
+      }
+    }
+  }
+
   return msg
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -987,6 +987,12 @@
         }
       }
     },
+    "base32-encode": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.1.1.tgz",
+      "integrity": "sha512-eqa0BeGghj3guezlasdHJhr3+J5ZbbQvxeprkcDMbRQrjlqOT832IUDT4Al4ofAwekFYMqkkM9KMUHs9Cu0HKA==",
+      "dev": true
+    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -1460,8 +1466,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -1482,14 +1487,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1504,20 +1507,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1634,8 +1634,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1647,7 +1646,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1662,7 +1660,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -1670,14 +1667,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -1696,7 +1691,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -1786,8 +1780,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1799,7 +1792,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -1885,8 +1877,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -1922,7 +1913,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -1942,7 +1932,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -1986,14 +1975,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dns-packet": "^5.2.1"
   },
   "devDependencies": {
+    "base32-encode": "^1.1.1",
     "jest": "^25.1.0",
     "jsdoc-to-markdown": "^5.0.3",
     "live-server": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "dependencies": {
     "argparse": "^1.0.10",
     "browserify": "^16.5.0",
-    "dns-packet": "^5.2.1"
+    "dns-packet": "^5.2.1",
+    "base32-encode": "^1.1.1"
   },
   "devDependencies": {
-    "base32-encode": "^1.1.1",
     "jest": "^25.1.0",
     "jsdoc-to-markdown": "^5.0.3",
     "live-server": "^1.2.1",

--- a/test.sh
+++ b/test.sh
@@ -26,9 +26,12 @@ doh_test --help
 doh_test --version
 doh_test https://dns.google/dns-query -m GET
 doh_test https://dns.google/dns-query
-doh_test https://cloudflare-dns.com/dns-query -t AAAA
-doh_test https://cloudflare-dns.com/dns-query -q example.net -t TXT -m GET
-doh_test https://dns.google/dns-query -m POST --ecs 1.2.3.4/24 -q google.com -t AAAA
-doh_test https://cloudflare-dns.com/dns-query -m POST --subnet ::/56 -q cloudflare.com -t A
+doh_test https://cloudflare-dns.com/dns-query dohjs.org AAAA
+doh_test https://cloudflare-dns.com/dns-query example.net TXT -m GET
+doh_test https://dns.google/dns-query -m POST +subnet 1.2.3.4/24 google.com AAAA
+doh_test https://cloudflare-dns.com/dns-query -m POST +subnet ::/56 cloudflare.com A
+doh_test https://cloudflare-dns.com/dns-query dohjs.org TXT -s -d
+doh_test https://cloudflare-dns.com/dns-query dohjs.org TXT -edns 12:0000
+
 echo "Command line tests passed"
 echo "All tests passed"

--- a/test.sh
+++ b/test.sh
@@ -31,7 +31,8 @@ doh_test https://cloudflare-dns.com/dns-query example.net TXT -m GET
 doh_test https://dns.google/dns-query -m POST +subnet 1.2.3.4/24 google.com AAAA
 doh_test https://cloudflare-dns.com/dns-query -m POST +subnet ::/56 cloudflare.com A
 doh_test https://cloudflare-dns.com/dns-query dohjs.org TXT -s -d
-doh_test https://cloudflare-dns.com/dns-query dohjs.org TXT -edns 12:0000
+doh_test https://cloudflare-dns.com/dns-query dohjs.org TXT +edns 12:0000
+doh_test https://cloudflare-dns.com/dns-query dohjs.org TXT +edns 12:0000 +edns 10:0011223344556677
 
 echo "Command line tests passed"
 echo "All tests passed"

--- a/test.sh
+++ b/test.sh
@@ -28,8 +28,8 @@ doh_test https://dns.google/dns-query -m GET
 doh_test https://dns.google/dns-query
 doh_test https://cloudflare-dns.com/dns-query dohjs.org AAAA
 doh_test https://cloudflare-dns.com/dns-query example.net TXT -m GET
-doh_test https://dns.google/dns-query -m POST +subnet 1.2.3.4/24 google.com AAAA
-doh_test https://cloudflare-dns.com/dns-query -m POST +subnet ::/56 cloudflare.com A
+doh_test https://dns.google/dns-query google.com AAAA -m POST +subnet 1.2.3.4/24
+doh_test https://cloudflare-dns.com/dns-query cloudflare.com -m POST +subnet ::/56
 doh_test https://cloudflare-dns.com/dns-query dohjs.org TXT -s -d
 doh_test https://cloudflare-dns.com/dns-query dohjs.org TXT +edns 12:0000
 doh_test https://cloudflare-dns.com/dns-query dohjs.org TXT +edns 12:0000 +edns 10:0011223344556677


### PR DESCRIPTION
Haven't really tested this yet. Open to any changes / feedback. The prettify stuff should really be handled in dnsPacket, but alas.

**Added prettify function to library**
* This converts aspects of the dnsPacket to a more human-friendly format
* Currently it replaces most `Buffer`s with their presentation-format string

**overhauled CLI to simplify code and add more options**
* added printing options of debug and short
  * debug prints the query and response
  * short prints json in 1 line (new default is to pretty print output)
* exposed dnssec options, added option for arbitrary EDNS

**Note** If merged, this will require changes to the web interface. Namely removing old prettifying code and replacing it with new function call