### PR TITLE
reject error instead of a string, destroy() instead of abort()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -200,18 +200,18 @@ function sendDohMsg(packet, url, method, headers, timeout) {
           const decoded = dnsPacket.decode(data);
           resolve(decoded);
         } catch (e) {
-          reject(`Failed to parse DNS packet: ${e}, raw response body: ${data}`)
+          reject(e);
         }
       });
     });
     request.on('error', (err) => {
-      request.abort();
+      request.destroy();
       return reject(err);
     });
     if (timeout) {
       timer = setTimeout(() => {
-        request.abort();
-        return reject(`Query timed out after ${timeout} milliseconds of inactivity`);
+        request.destroy();
+        return reject(new Error(`Query timed out after ${timeout} milliseconds of inactivity`));
       }, timeout);
     }
     if (method === 'POST') {

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -49,7 +49,6 @@ test('Resolving with invalid methods causes error', async () => {
   try {
     await resolver.query('example.com', 'A', 'PUT');
   } catch (e) {
-    console.log('[INFO] got error:', e);
     expect(e).toBeInstanceOf(MethodNotAllowedError);
     return;
   }
@@ -71,7 +70,6 @@ test('timeout works properly (and cloudflare doesn\'t respond within 1 milliseco
   try {
     await sendDohMsg(msg, 'https://1.1.1.1/dns-query', 'GET', null, 1)
   } catch (e) {
-      console.log('[INFO] got error:', e);
       expect(e.toString()).toMatch(/.*timed out.*/);
       return;
   }


### PR DESCRIPTION
- reject error instead of a string (see https://github.com/byu-imaal/dohjs/issues/56#issuecomment-863744970)
- request.abort() is deprecated, use destroy() instead
- remove console.log()s from tests